### PR TITLE
Adjusted spread logic in RandomSpawner.cs

### DIFF
--- a/Assets/Scenes/TestScenes/Umar Level 2.unity
+++ b/Assets/Scenes/TestScenes/Umar Level 2.unity
@@ -7922,6 +7922,7 @@ MonoBehaviour:
     m_Bits: 8
   spreadFactor: 1
   allowSpawnInColliders: 0
+  maxRetries: 999999
 --- !u!1 &1323742112
 GameObject:
   m_ObjectHideFlags: 0
@@ -11145,8 +11146,9 @@ MonoBehaviour:
   spawnableLayer:
     serializedVersion: 2
     m_Bits: 1
-  spreadFactor: 20
+  spreadFactor: 50
   allowSpawnInColliders: 0
+  maxRetries: 0
 --- !u!4 &1658949407
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Collectables/RandomSpawner.cs
+++ b/Assets/Scripts/Collectables/RandomSpawner.cs
@@ -28,21 +28,21 @@ public class RandomSpawner : MonoBehaviour
             {
                 retries++;
 
-                // Randomize position within the spawn area, with some spread factor to ensure they aren't clamped together
+                // Randomize position within the spawn area, with a controlled spread factor to prevent out-of-bounds spawning
                 Vector3 randomPosition = new Vector3(
-                    Random.Range(-spawnArea.x, spawnArea.x),
-                    Random.Range(-spawnArea.y, spawnArea.y),
-                    Random.Range(-spawnArea.z, spawnArea.z)
+                    Mathf.Clamp(Random.Range(-spawnArea.x, spawnArea.x), -spawnArea.x, spawnArea.x),  // Clamp to spawn area limits
+                    Mathf.Clamp(Random.Range(-spawnArea.y, spawnArea.y), -spawnArea.y, spawnArea.y),  // Clamp to spawn area limits
+                    Mathf.Clamp(Random.Range(-spawnArea.z, spawnArea.z), -spawnArea.z, spawnArea.z)   // Clamp to spawn area limits
                 );
 
                 // Offset this position by the Spawner's current position
                 randomPosition += transform.position;
 
-                // Apply spread factor: adding random offset based on the spread factor
+                // Apply spread factor: adding random offset based on the spread factor but ensuring it stays within bounds
                 randomPosition += new Vector3(
-                    Random.Range(-spreadFactor, spreadFactor),
-                    Random.Range(-spreadFactor, spreadFactor),
-                    Random.Range(-spreadFactor, spreadFactor)
+                    Mathf.Clamp(Random.Range(-spreadFactor, spreadFactor), -spawnArea.x, spawnArea.x),
+                    Mathf.Clamp(Random.Range(-spreadFactor, spreadFactor), -spawnArea.y, spawnArea.y),
+                    Mathf.Clamp(Random.Range(-spreadFactor, spreadFactor), -spawnArea.z, spawnArea.z)
                 );
 
                 // Check if the position is valid (on the "Spawnable" layer and not colliding with other objects)


### PR DESCRIPTION
Objects being spawned should keep to the drawn box more often and distribute more evenly with a higher spread